### PR TITLE
Format lib.rs better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33.3"
 walkdir = "2.3.1"
-tonic-build = {version = "0.3.1", default-features = false, features = ["prost", "transport"] }
+tonic-build = {version = "0.3.1", default-features = false, features = ["rustfmt", "prost", "transport"] }
 
 # Until fix has been approved in Prost master and/or released we use a patched version of Prost to
 # allow for using protoc from current environment. /Olle


### PR DESCRIPTION
Format lib.rs better even when `rustfmt` is missing.
Also allow to disable `rustfmt` from being run at all.