### PR TITLE
fix: release binaries with PROTOC set

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Build Release Binary
         if: startsWith(github.ref, 'refs/tags/')
         run: cargo build --all --release && strip target/release/${{ env.BIN_NAME }} && mv target/release/${{ env.BIN_NAME }} target/release/${{ env.BIN_NAME }}_${{ matrix.target }}
+        env:
+          PROTOC: protoc
+          PROTOC_INCLUDE: .
 
       - name: Attach Release Binaries
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
So that protoc from the current path is used by the prebuilt binaries.

Went missing when moved from cloudbuild to github workflow.