### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@einride/team-a2b
+ *       @einride/team-path-following


### PR DESCRIPTION
Update ownership from a2b to path-following